### PR TITLE
Fix paths for zip demos (CHARTS-194)

### DIFF
--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -36,11 +36,7 @@ gulp.task('zip:install-dependencies-temp', function () {
 
 gulp.task('zip:copy-demo', function () {
     return gulp.src(config.files.demo)
-        .pipe(deleteLines({
-            'filters': [
-                /<script\s+src=["']/i
-            ]
-        }))
+        .pipe(replace('../', '../src/'))
         .pipe(gulp.dest(zipDest + 'demo'));
 });
 


### PR DESCRIPTION
After this change the zip demos don't use the vulcanized v-chart
anymore.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/charts-component/35)
<!-- Reviewable:end -->
