### PR TITLE
Read light DOM configuration in attach instead of ready

### DIFF
--- a/chart-behavior.html
+++ b/chart-behavior.html
@@ -187,7 +187,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         attached: function () {
-            this._initChart();
+          this._initLocalDom();
+          this._initConfiguration();
+
+          Polymer.dom(this).querySelectorAll("data-series").forEach(function(ds) {
+              ds.initialize();
+          });
+          if (this._loadTheme) {
+              this._loadTheme();
+          }
+          this._initChart();
         },
 
         /**
@@ -203,12 +212,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         ready: function () {
-            this._initLocalDom();
-            this._initConfiguration();
 
-            if (this._loadTheme) {
-                this._loadTheme();
-            }
         },
 
         _initLocalDom: function () {

--- a/data-series.html
+++ b/data-series.html
@@ -224,7 +224,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
 
-        ready: function () {
+        // Kind of attached but attached is not called then the element is only in the light DOM
+        initialize: function () {
             this._initConfiguration();
             if (this.drilldown) {
                 this._seriesIndex = this._parentChart()._addDrilldownSeries(this._seriesConf);

--- a/test/chart-using-javascript.html
+++ b/test/chart-using-javascript.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Charts are awesome</title>
+  <link rel="import" href="vaadin-column-chart.html">
+  <script src="../webcomponentsjs/webcomponents-lite.min.js"></script>
+  
+  <script>
+  	HTMLImports.whenReady(function() {
+  	var chart = document.createElement("vaadin-column-chart");
+  	var t = document.createElement("title");
+  	var ds = document.createElement("data-series");
+  	t.textContent = "Foobar title";
+  	ds.setAttribute("name","foobars");
+  	var data = document.createElement("data");
+  	data.textContent="10,20,30,10,20,30";
+  	Polymer.dom(ds).appendChild(data);
+  	Polymer.dom(chart).appendChild(t);
+  	Polymer.dom(chart).appendChild(ds);
+  	document.body.appendChild(chart);
+  	});
+  </script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
If you create a chart using Javascript, then the light DOM
is not be setup when the ready is fired, and thus the chart
will always be empty.

This change modifies the behavior so the light DOM is ready when
the <vaadin-some-chart> is attached to the document. At this point
the light DOM must be ready.

Inner <data-series> cannot use the attached event as they are never attached
to the document, they are only added to the light DOM.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/charts-component/52)
<!-- Reviewable:end -->
