### PR TITLE
Task/lightdomattach

### DIFF
--- a/chart-behavior.html
+++ b/chart-behavior.html
@@ -74,14 +74,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
 
             /**
-             * Flag to indicate when this component has initialized itself for the first time.
-             **/
-            initialized: {
-                type: Boolean,
-                value: false
-            },
-
-            /**
              * Initial chart configuration before initial rendering.
              **/
             _chartConf: {
@@ -90,6 +82,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
                     return {chart: {}};
                 }
             }
+        },
+
+        /**
+         * Tells that the component has been initialized.
+         **/
+        isInitialized: function() {
+          return Object.keys(this.chart).length !== 0;
         },
 
         /**
@@ -187,28 +186,25 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         attached: function () {
-          this._initLocalDom();
-          this._initConfiguration();
-
-          Polymer.dom(this).querySelectorAll("data-series").forEach(function(ds) {
-              ds.initialize();
-          });
-          if (this._loadTheme) {
-              this._loadTheme();
-          }
-          this._initChart();
+            if (!this.isInitialized()) {
+                this._initLocalDom();
+                this._initConfiguration();
+                Polymer.dom(this).querySelectorAll("data-series").forEach(function(ds) {
+                    ds.initialize();
+                });
+                if (this._loadTheme) {
+                    this._loadTheme();
+                }
+                this._initChart();
+            }
         },
 
         /**
          * Initializes the chart property using the json configuration.
          */
         _initChart: function () {
-            //Only initialize once
-            if (Object.keys(this.chart).length === 0) {
-                this.chart = new Highcharts.Chart(this._chartConf);
-                this.initialized = true;
-                this.fire("chart-loaded");
-            }
+            this.chart = new Highcharts.Chart(this._chartConf);
+            this.fire("chart-loaded");
         },
 
         ready: function () {
@@ -216,18 +212,15 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         _initLocalDom: function () {
-            if (!this.initialized) {
-                var chartContainer = document.createElement('div');
-                chartContainer.id = "chartContainer";
-                chartContainer.setAttribute("style", "height:100%; width:100%;");
-                Polymer.dom(this.root).appendChild(chartContainer);
-
-                var licenseChecker = document.createElement('vaadin-license-checker');
-                licenseChecker.productName = "vaadin-charts";
-                licenseChecker.productVersion = "3";
-                licenseChecker.productCaption = "Vaadin Charts";
-                Polymer.dom(this.root).appendChild(licenseChecker);
-            }
+            var chartContainer = document.createElement('div');
+            chartContainer.id = "chartContainer";
+            chartContainer.setAttribute("style", "height:100%; width:100%;");
+            Polymer.dom(this.root).appendChild(chartContainer);
+            var licenseChecker = document.createElement('vaadin-license-checker');
+            licenseChecker.productName = "vaadin-charts";
+            licenseChecker.productVersion = "3";
+            licenseChecker.productCaption = "Vaadin Charts";
+            Polymer.dom(this.root).appendChild(licenseChecker);
         },
 
         /**

--- a/chart-behavior.html
+++ b/chart-behavior.html
@@ -187,7 +187,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         attached: function () {
-            this._initChart();
+          this._initLocalDom();
+          this._initConfiguration();
+
+          Polymer.dom(this).querySelectorAll("data-series").forEach(function(ds) {
+              ds.initialize();
+          });
+          if (this._loadTheme) {
+              this._loadTheme();
+          }
+          this._initChart();
         },
 
         /**
@@ -203,12 +212,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
         ready: function () {
-            this._initLocalDom();
-            this._initConfiguration();
 
-            if (this._loadTheme) {
-                this._loadTheme();
-            }
         },
 
         _initLocalDom: function () {

--- a/data-series.html
+++ b/data-series.html
@@ -86,7 +86,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * Updates chart data when series data changes
          */
         _dataChanged: function () {
-            if (this._seriesIndex != undefined && this._parentChart().initialized) {
+            if (this._seriesIndex != undefined && this._parentChart().isInitialized()) {
                 if (this.drilldown) {
                     this._parentChart().chart.drilldown.series[this._seriesIndex].setData(this.data);
                 } else {

--- a/data-series.html
+++ b/data-series.html
@@ -224,7 +224,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         },
 
 
-        ready: function () {
+        // Kind of attached but attached is not called then the element is only in the light DOM
+        initialize: function () {
             this._initConfiguration();
             if (this.drilldown) {
                 this._seriesIndex = this._parentChart()._addDrilldownSeries(this._seriesConf);

--- a/demo/line_and_scatter/time-data-with-irregular-intervals.html
+++ b/demo/line_and_scatter/time-data-with-irregular-intervals.html
@@ -1,4 +1,4 @@
-<vaadin-spline-chartt id="time-data-with-irregular-intervals">
+<vaadin-spline-chart id="time-data-with-irregular-intervals">
     <title>Snow depth at Vikjafjellet, Norway</title>
 
     <x-axis type="datetime">
@@ -141,4 +141,4 @@
             [Date.UTC(1971, 5, 23), 1.08]
         </data>
     </data-series>
-</vaadin-spline-chartt>
+</vaadin-spline-chart>

--- a/test/chart-init-test.html
+++ b/test/chart-init-test.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../vaadin-line-chart.html">
+</head>
+<body>
+
+<script>
+    suite('<vaadin-_-chart>', function () {
+
+        test('Test that chart initialization is done only once', function (done) {
+            HTMLImports.whenReady(function () {
+
+                var chartwc = document.createElement("vaadin-line-chart");
+                chartwc.setAttribute("id","chartid");
+                var title = document.createElement("title");
+                var ds = document.createElement("data-series");
+                var axis = document.createElement("x-axis");
+                var parent = document.createElement("div");
+                var newParent = document.createElement("div");
+                var data = document.createElement("data");
+
+                data.textContent = "10,20,30,10,20,30";
+                Polymer.dom(ds).appendChild(data);
+                Polymer.dom(chartwc).appendChild(title);
+                Polymer.dom(chartwc).appendChild(axis);
+                Polymer.dom(chartwc).appendChild(ds);
+
+                document.body.appendChild(parent);
+                document.body.appendChild(newParent);
+
+                chartwc.addEventListener("chart-loaded", function () {
+                    //After deattach /attach chart to a page, the n of Series and axis
+                    //should stay the same
+                    expect(chartwc.chart.options.series.length).to.equal(1);
+                    expect(chartwc._chartConf.xAxis.length).to.equal(1);
+
+                    parent.removeChild(chartwc);
+                    newParent.appendChild(chartwc);
+                    expect(chartwc.chart.options.series.length).to.equal(1);
+                    expect(chartwc._chartConf.xAxis.length).to.equal(1);
+                    done();
+
+                });
+
+                Polymer.dom(parent).appendChild(chartwc);
+
+            });
+        });
+    });
+
+</script>
+
+</body>
+</html>

--- a/test/chart-javascript-test.html
+++ b/test/chart-javascript-test.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../vaadin-column-chart.html">
+</head>
+<body>
+
+<script>
+    suite('<vaadin-_-chart>', function () {
+
+        test('chart and series programmatically added', function (done) {
+            HTMLImports.whenReady(function () {
+                var chartwc = document.createElement("vaadin-column-chart");
+                var title = document.createElement("title");
+                var ds = document.createElement("data-series");
+                title.textContent = "Foobar title";
+                ds.setAttribute("name", "foobars");
+                var data = document.createElement("data");
+                data.textContent = "10,20,30,10,20,30";
+                Polymer.dom(ds).appendChild(data);
+                Polymer.dom(chartwc).appendChild(title);
+                Polymer.dom(chartwc).appendChild(ds);
+                chartwc.addEventListener("chart-loaded", function () {
+                    expect(chartwc.chart.redraw).to.exist;
+                    expect(chartwc.chart.series[0].name).to.equal("foobars");
+                    expect(chartwc.chart.series[0].data.length).to.equal(6);
+                    document.body.removeChild(chartwc);
+                    done();
+                });
+                document.body.appendChild(chartwc);
+            });
+        });
+    });
+
+</script>
+
+</body>
+</html>

--- a/test/chart-reload-test.html
+++ b/test/chart-reload-test.html
@@ -48,7 +48,7 @@
                     },
                     _addSeriesPoint: function () {
                         var x = (new Date()).getTime(),
-                                y = Math.random();
+                                y = Math.floor(Math.random() * 40) + 1 ;
                         this.push('seriesData', [x, y]);
                     },
                     _changeTitle: function () {

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
         'chart-empty-test.html',
         'chart-events-test.html',
         'chart-fill-color.html',
+        'chart-init-test.html',
         'chart-javascript-test.html',
         'chart-load-event-test.html',
         'chart-multiple-test.html',
@@ -36,6 +37,7 @@
         'series-single-dimension-data.html',
         'series-two-dimension-data.html',
         'series-two-dimension-date-data.html'
+
     ]);
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
         'chart-empty-test.html',
         'chart-events-test.html',
         'chart-fill-color.html',
+        'chart-javascript-test.html',
         'chart-load-event-test.html',
         'chart-multiple-test.html',
         'chart-reload-test.html',


### PR DESCRIPTION

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/charts-component/54)
<!-- Reviewable:end -->
Read light DOM configuration in attach instead of ready
If you create a chart using Javascript, then the light DOM
is not be setup when the ready is fired, and thus the chart
will always be empty.

This change modifies the behavior so the light DOM is ready when
the <vaadin-some-chart> is attached to the document. At this point
the light DOM must be ready.

Inner <data-series> cannot use the attached event as they are never attached
to the document, they are only added to the light DOM.