### PR TITLE
Bug/charts 286

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,20 +29,18 @@
   ],
   "dependencies": {
     "highcharts": "highslide-software/highcharts-release#v4.1.8",
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^1.1.0",
     "vaadin-license-checker": "vaadin/license-checker#0.9.0"
   },
   "devDependencies": {
     "vaadin-components": "^0.3.0",
     "google-code-prettify": "*",
+    "iron-selector": "PolymerElements/iron-selector#v1.0.7",
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^1.0.0",
     "iron-menu-behavior": "PolymerElements/iron-menu-behavior#^1.0.0",
     "iron-pages": "PolymerElements/iron-pages#^1.0.0",
     "paper-tabs": "PolymerElements/paper-tabs#^1.0.0",
     "web-component-tester": "*"
-  },
-  "resolutions": {
-    "polymer": "^1.2.0"
   }
 }

--- a/demo/menu-tree.html
+++ b/demo/menu-tree.html
@@ -9,7 +9,7 @@ A tree menu for selecting categories and demos.
 
         .category-items {
             /* Approximation of the max height needed */
-            max-height: 500px;
+            max-height: 1500px;
 
             -webkit-transition: max-height 0.3s;
             -moz-transition: max-height 0.3s;


### PR DESCRIPTION
This fixes the problem in the demo that everything is not visible in the 'Others' section.

Also bower.json configured to not use polymer 1.2 at it brokes sizing (CHARTS-278)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/charts-component/57)
<!-- Reviewable:end -->
