### PR TITLE
Fixed issue with flexbox layout (CHARTS-278)

### DIFF
--- a/chart-behavior.html
+++ b/chart-behavior.html
@@ -87,9 +87,14 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         /**
          * Tells that the component has been initialized.
          **/
-        isInitialized: function() {
-          return Object.keys(this.chart).length !== 0;
+        isInitialized: function () {
+            return Object.keys(this.chart).length !== 0;
         },
+
+        /**
+         * List of properties that will always be copied from the chart element to the container div
+         **/
+        _styleProperties: ["flex", "-webkit-flex", "-ms-flex"],
 
         /**
          *  Name of the chart events to add to the configuration and its corresponding event for the chart element
@@ -189,7 +194,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             if (!this.isInitialized()) {
                 this._initLocalDom();
                 this._initConfiguration();
-                Polymer.dom(this).querySelectorAll("data-series").forEach(function(ds) {
+                Polymer.dom(this).querySelectorAll("data-series").forEach(function (ds) {
                     ds.initialize();
                 });
                 if (this._loadTheme) {
@@ -214,13 +219,43 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         _initLocalDom: function () {
             var chartContainer = document.createElement('div');
             chartContainer.id = "chartContainer";
-            chartContainer.setAttribute("style", "height:100%; width:100%;");
+            this._updateStyles(chartContainer);
             Polymer.dom(this.root).appendChild(chartContainer);
             var licenseChecker = document.createElement('vaadin-license-checker');
             licenseChecker.productName = "vaadin-charts";
             licenseChecker.productVersion = "3";
             licenseChecker.productCaption = "Vaadin Charts";
             Polymer.dom(this.root).appendChild(licenseChecker);
+            Polymer.dom.flush();
+        },
+
+        /**
+         * Updates chartContainer and current chart style property depending on flex status
+         */
+        _updateStyles: function (chartContainer) {
+            var isFlex = false;
+            this._styleProperties.forEach(function (property) {
+                //Chrome returns default value if property is not set
+                //check if flex is defined for chart, and different than default value
+                if (getComputedStyle(this)[property] && getComputedStyle(this)[property] != "0 1 auto") {
+                    isFlex = true;
+                }
+            }, this);
+            //If chart element is a flexible item the chartContainer should be flex too
+            if (isFlex) {
+                chartContainer.setAttribute("style", "flex: 1; -webkit-flex: 1; -ms-flex: 1; ");
+                var style = '';
+                if (this.hasAttribute("style")) {
+                    style = this.getAttribute("style");
+                    if (style.charAt(style.length - 1) !== ';') {
+                        style += ';'
+                    }
+                }
+                style += "display: -ms-flexbox; display: -webkit-flex; display: flex;";
+                this.setAttribute("style", style);
+            } else {
+                chartContainer.setAttribute("style", "height:100%; width:100%;");
+            }
         },
 
         /**

--- a/demo/combination/dual-charts.html
+++ b/demo/combination/dual-charts.html
@@ -1,40 +1,36 @@
-<div style=" width: 50%; float: left;">
-    <vaadin-bar-chart id="stacked-bar">
-        <title>Stacked bar chart</title>
-        <x-axis>
-            <categories>Apples, Oranges, Pears, Grapes, Bananas</categories>
-        </x-axis>
-        <y-axis min="0">
-            <title>Total fruit consumption</title>
-        </y-axis>
-        <legend reversed="true"></legend>
-        <tooltip point-format="{series.name}: {point.y}. Total: {point.stackTotal}"></tooltip>
-        <plot-options>
-            <series stacking="normal">
-            </series>
-        </plot-options>
-        <data-series name="John">
-            <data>5, 3, 4, 7, 2</data>
-        </data-series>
-        <data-series name="Jane">
-            <data>2, 2, 3, 2, 1</data>
-        </data-series>
-        <data-series name="Joe">
-            <data>3, 4, 4, 2, 5</data>
-        </data-series>
-    </vaadin-bar-chart>
-</div>
-<div style=" width: 50%; float: left;">
-    <vaadin-pie-chart id="pieWithSeries">
-        <data-series name="Browser share">
-            <data>
-                ["Firefox", 45.0],
-                ["IE", 26.8],
-                ["Chrome", 12.8],
-                ["Safari", 8.5],
-                ["Opera", 6.2],
-                ["Others", 0.7]
-            </data>
-        </data-series>
-    </vaadin-pie-chart>
-</div>
+<vaadin-bar-chart id="stacked-bar" style=" width: 50%; float: left;">
+    <title>Stacked bar chart</title>
+    <x-axis>
+        <categories>Apples, Oranges, Pears, Grapes, Bananas</categories>
+    </x-axis>
+    <y-axis min="0">
+        <title>Total fruit consumption</title>
+    </y-axis>
+    <legend reversed="true"></legend>
+    <tooltip point-format="{series.name}: {point.y}. Total: {point.stackTotal}"></tooltip>
+    <plot-options>
+        <series stacking="normal">
+        </series>
+    </plot-options>
+    <data-series name="John">
+        <data>5, 3, 4, 7, 2</data>
+    </data-series>
+    <data-series name="Jane">
+        <data>2, 2, 3, 2, 1</data>
+    </data-series>
+    <data-series name="Joe">
+        <data>3, 4, 4, 2, 5</data>
+    </data-series>
+</vaadin-bar-chart>
+<vaadin-pie-chart id="pieWithSeries" style=" width: 50%; float: left;">
+    <data-series name="Browser share">
+        <data>
+            ["Firefox", 45.0],
+            ["IE", 26.8],
+            ["Chrome", 12.8],
+            ["Safari", 8.5],
+            ["Opera", 6.2],
+            ["Others", 0.7]
+        </data>
+    </data-series>
+</vaadin-pie-chart>

--- a/test/chart-flexbox-size.html
+++ b/test/chart-flexbox-size.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../vaadin-line-chart.html">
+    <link rel="import" href="../vaadin-column-chart.html">
+    <link rel="import" href="../vaadin-pie-chart.html">
+    <style>
+        html, body {
+            height: 100%;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        #flex-column {
+            height: 100%;
+
+            display: -ms-flexbox; /* IE */
+            -ms-flex-direction: column;
+
+            display: -webkit-flex; /* Safari */
+            -webkit-flex-direction: column;
+
+            display: flex;
+            flex-direction: column;
+        }
+
+        #flex-row {
+            display: -ms-flexbox; /* IE */
+            -ms-flex: 1;
+
+            display: -webkit-flex; /* Safari */
+            -webkit-flex: 1;
+
+            display: flex;
+            flex: 1;
+        }
+
+        .box {
+            -ms-flex: 1;
+            -webkit-flex: 1;
+            flex: 1;
+        }
+
+        #header {
+            font-size: 22px;
+            font-weight: bold;
+        }
+
+    </style>
+
+</head>
+<body>
+<div id="flex-column">
+    <div id="flex-row">
+        <div class="box"
+             style="background-color:#d1e87b; display: -ms-flexbox; display: -webkit-flex; display:flex; -ms-flex: 1; -webkit-flex: 1;  flex:1; ">
+            <vaadin-line-chart id="line" style="-ms-flex: 1;  -webkit-flex: 1; flex:1; ">
+                <title>People rocking</title>
+                <data-series name="Persons">
+                    <data>20,25,30,40,50,65,80</data>
+                </data-series>
+                <x-axis>
+                    <categories>2008,2009,2010,2011,2012,2013,2014</categories>
+                </x-axis>
+            </vaadin-line-chart>
+        </div>
+        <div class="box"
+             style="background-color:#f59694;display: -ms-flexbox; display: -webkit-flex; display:flex; -ms-flex: 1; -webkit-flex: 1;  flex:1;">
+            <vaadin-pie-chart id="pie" class="box">
+                <title>Browser market shares at a specific website, 2010</title>
+                <tooltip point-format="{series.name}: <b>{point.percentage:.1f}%</b>">
+                </tooltip>
+                <plot-options>
+                    <pie allow-point-select="true" cursor="pointer">
+                        <data-labels enabled="true" format="<b>{point.name}</b>:    {point.percentage:.1f} %">
+                        </data-labels>
+                    </pie>
+                </plot-options>
+
+                <data-series name="Browser share">
+                    <data>
+                        ["Firefox", 45.0], ["IE", 26.8], ["Chrome", 12.8], ["Safari", 8.5], ["Opera", 6.2], ["Others",
+                        0.7]
+                    </data>
+                </data-series>
+            </vaadin-pie-chart>
+        </div>
+    </div>
+    <div class="box"
+         style="background-color:#acf6e7; display: -ms-flexbox; display: -webkit-flex; display:flex; -ms-flex: 1; -webkit-flex: 1;  flex:1;">
+        <vaadin-column-chart id="column" style="-ms-flex: 1; -webkit-flex: 1;  flex:1; ">
+            <title>Stacked column chart</title>
+            <x-axis>
+                <categories>Apples, Oranges, Pears, Grapes, Bananas</categories>
+            </x-axis>
+            <y-axis allow-decimals="false" min="0">
+                <title>Number of fruits</title>
+                <stack-labels enabled="true"></stack-labels>
+            </y-axis>
+            <tooltip
+                    point-format='<span style="color:{series.color}">{series.name}</span>: <b>{point.y}</b> ({point.percentage:.0f}%)<br/>'
+                    shared="true"></tooltip>
+            <plot-options>
+                <column stacking="percent">
+                    <data-labels enabled="true" color="white"></data-labels>
+                </column>
+            </plot-options>
+            <data-series name="John">
+                <data>5, 3, 4, 7, 2</data>
+            </data-series>
+            <data-series name="Jane">
+                <data>2, 2, 3, 2, 1</data>
+            </data-series>
+            <data-series name="Joe">
+                <data>3, 4, 4, 2, 5</data>
+            </data-series>
+        </vaadin-column-chart>
+
+    </div>
+</div>
+<script>
+
+    suite('<vaadin-_-chart>', function () {
+
+        setup(function () {
+            //page shouldn't have scrollbars if test layout is correct
+            expect(document.body.scrollHeight).to.equal(document.body.clientHeight);
+        });
+
+        test('line chart with flex in style is half height and half width', function () {
+            var container = document.querySelector('#line #chartContainer');
+            checkSize(container, 2, 2);
+        });
+        test('pie chart with flex in class is half height and half width', function () {
+            var container = document.querySelector('#pie #chartContainer');
+            checkSize(container, 2, 2);
+        });
+        test('column chart is half height and full width', function () {
+            var container = document.querySelector('#column #chartContainer');
+            checkSize(container, 2, 1);
+        });
+    });
+
+    /**
+     * Checks that elem height is 1/heightDivisor times page height and elem width is 1/widthDivisor times page width
+     * @param elem element to check size
+     * @param heightDivisor divisor for height
+     * @param widthDivisor divisor for width
+     */
+    function checkSize(elem, heightDivisor, widthDivisor) {
+        heightDivisor = typeof heightDivisor !== 'undefined' ? heightDivisor : 1;
+        widthDivisor = typeof widthDivisor !== 'undefined' ? widthDivisor : 1;
+
+        expect(elem.offsetHeight).to.equal(Math.round(document.documentElement.offsetHeight / heightDivisor));
+        expect(elem.offsetWidth).to.equal(Math.round(document.documentElement.offsetWidth / widthDivisor));
+    }
+
+
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
         'chart-empty-test.html',
         'chart-events-test.html',
         'chart-fill-color.html',
+        'chart-flexbox-size.html',
         'chart-init-test.html',
         'chart-javascript-test.html',
         'chart-load-event-test.html',


### PR DESCRIPTION
Chart now copies flex related style properties to chart container div
to ensure size calculations work in highcharts.
Style properties not related to flex are not copied and work correctly (CHARTS-184)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/charts-component/58)
<!-- Reviewable:end -->
